### PR TITLE
feat: support multiple connection strings via env list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,22 @@ This MCP server provides AI agents with robust, reliable access to Microsoft SQL
 
 ## Configuration
 
-### Required Environment Variables
+### Environment Variables
 
-The MCP server requires a single environment variable:
+The MCP server looks for connection strings using environment variables:
 
-- **`MSSQL_CONNECTION_STRING`**: Complete SQL Server connection string
+- **`MSSQL_CONNECTION_STRING`**: Complete SQL Server connection string used when no other configuration is provided.
+- **`MSSQL_CONNECTION_STRING_ENV_NAMES`** (optional): Comma-separated list of environment variable names containing connection strings. If provided, each listed variable must be defined. The first name in the list becomes the default connection.
+
+#### Multiple Connection Strings Example
+
+```
+MSSQL_CONNECTION_STRING_ENV_NAMES=MSSQL_CS1,MSSQL_CS2
+MSSQL_CS1="Server=localhost;Database=Db1;Trusted_Connection=true;"
+MSSQL_CS2="Server=localhost;Database=Db2;Trusted_Connection=true;"
+```
+
+If `MSSQL_CONNECTION_STRING_ENV_NAMES` is not set, the server falls back to `MSSQL_CONNECTION_STRING` as before.
 
 #### Example Connection Strings
 

--- a/src/MSSQL.MCP/Program.cs
+++ b/src/MSSQL.MCP/Program.cs
@@ -23,21 +23,33 @@ public static class Program
             consoleLogOptions.LogToStandardErrorThreshold = LogLevel.Trace;
         });
 
-        // Retrieve the connection string from environment variables
-        var connectionString = Environment.GetEnvironmentVariable("MSSQL_CONNECTION_STRING");
+        // Retrieve connection string environment variables
+        var connectionNamesVar = Environment.GetEnvironmentVariable("MSSQL_CONNECTION_STRING_ENV_NAMES");
+        var connectionNames = string.IsNullOrWhiteSpace(connectionNamesVar)
+            ? new[] { "MSSQL_CONNECTION_STRING" }
+            : connectionNamesVar.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        if (string.IsNullOrWhiteSpace(connectionString))
+        var connections = new List<(string Name, string ConnectionString)>();
+        foreach (var name in connectionNames)
         {
-            await Console.Error.WriteLineAsync("Error: MSSQL_CONNECTION_STRING environment variable is not set.");
-            Environment.Exit(1);
-            return;
+            var cs = Environment.GetEnvironmentVariable(name);
+            if (string.IsNullOrWhiteSpace(cs))
+            {
+                await Console.Error.WriteLineAsync($"Error: {name} environment variable is not set.");
+                Environment.Exit(1);
+                return;
+            }
+            connections.Add((name, cs));
         }
 
-        // Register IDbConnectionFactory with the connection string
-        builder.Services.AddSingleton<IDbConnectionFactory>(provider =>
+        // Register a default IDbConnectionFactory and keyed factories for each connection
+        var defaultConnection = connections[0];
+        builder.Services.AddSingleton<IDbConnectionFactory>(_ => new SqlConnectionFactory(defaultConnection.ConnectionString));
+
+        foreach (var (name, cs) in connections)
         {
-            return new SqlConnectionFactory(connectionString);
-        });
+            builder.Services.AddKeyedSingleton<IDbConnectionFactory>(name, (_, _) => new SqlConnectionFactory(cs));
+        }
 
         // Register MCP server and tools (instance-based)
         builder.Services
@@ -48,14 +60,19 @@ public static class Program
         // Build the host
         var host = builder.Build();
 
-
-        // Test the database connection before running the host
+        // Test all database connections before running the host
         try
         {
-            var dbFactory = host.Services.GetRequiredService<IDbConnectionFactory>();
-            using var connection = dbFactory.CreateConnection();
-            await connection.OpenAsync();
-            Console.WriteLine("Database connection test succeeded.");
+            foreach (var (name, _) in connections)
+            {
+                IDbConnectionFactory dbFactory = name == defaultConnection.Name
+                    ? host.Services.GetRequiredService<IDbConnectionFactory>()
+                    : host.Services.GetRequiredKeyedService<IDbConnectionFactory>(name);
+
+                using var connection = dbFactory.CreateConnection();
+                await connection.OpenAsync();
+                Console.WriteLine($"Database connection test succeeded for '{name}'.");
+            }
         }
         catch (Exception dbEx)
         {

--- a/src/MSSQL.MCP/Tools/SqlExecutionTool.cs
+++ b/src/MSSQL.MCP/Tools/SqlExecutionTool.cs
@@ -9,12 +9,21 @@ using MSSQL.MCP.Database;
 namespace MSSQL.MCP.Tools;
 
 [McpServerToolType]
-public class SqlExecutionTool(IDbConnectionFactory connectionFactory, ILogger<SqlExecutionTool> logger)
+public class SqlExecutionTool(IDbConnectionFactory connectionFactory, ILogger<SqlExecutionTool> logger, IServiceProvider? serviceProvider = null)
 {
+    private readonly IDbConnectionFactory _defaultConnectionFactory = connectionFactory;
+    private readonly ILogger<SqlExecutionTool> _logger = logger;
+    private readonly IServiceProvider _serviceProvider = serviceProvider ?? new ServiceCollection().BuildServiceProvider();
+
     // Regex to detect valid T-SQL keywords at the beginning of queries
     private static readonly Regex ValidTSqlStartPattern = new(
         @"^\s*(SELECT|INSERT|UPDATE|DELETE|WITH|CREATE|ALTER|DROP|GRANT|REVOKE|EXEC|EXECUTE|DECLARE|SET|USE|BACKUP|RESTORE|TRUNCATE|MERGE)\s+",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    private IDbConnectionFactory ResolveFactory(string? connectionName) =>
+        string.IsNullOrWhiteSpace(connectionName)
+            ? _defaultConnectionFactory
+            : _serviceProvider.GetRequiredKeyedService<IDbConnectionFactory>(connectionName);
 
     [McpServerTool, Description(@"Execute T-SQL queries against the connected Microsoft SQL Server database. 
     
@@ -36,19 +45,21 @@ Examples of valid T-SQL:
 
 The query parameter must contain ONLY the T-SQL statement - no explanations, markdown, or other text.")]
     public async Task<string> ExecuteSql(
-        [Description(@"The T-SQL query to execute. Must be valid Microsoft SQL Server T-SQL syntax only. 
+        [Description(@"The T-SQL query to execute. Must be valid Microsoft SQL Server T-SQL syntax only.
         Examples: 'SELECT * FROM Users', 'INSERT INTO Products VALUES (1, ''Name'')', 'CREATE TABLE Test (ID int)'
-        Do NOT include explanations, markdown formatting, or non-SQL text.")] 
+        Do NOT include explanations, markdown formatting, or non-SQL text.")]
         string query,
+        [Description("Optional name of the connection string to use, from MSSQL_CONNECTION_STRING_ENV_NAMES. Defaults to the first connection.")]
+        string? connectionName = null,
         CancellationToken cancellationToken = default)
     {
         // Log the incoming query for debugging
-        logger.LogInformation("Received SQL execution request. Query length: {QueryLength} characters", query.Length );
-        logger.LogDebug("SQL Query received: {Query}", query);
+        _logger.LogInformation("Received SQL execution request. Query length: {QueryLength} characters", query.Length );
+        _logger.LogDebug("SQL Query received: {Query}", query);
 
         if (string.IsNullOrWhiteSpace(query))
         {
-            logger.LogWarning("Empty or null query received");
+            _logger.LogWarning("Empty or null query received");
             return "Error: SQL query cannot be empty";
         }
 
@@ -56,7 +67,7 @@ The query parameter must contain ONLY the T-SQL statement - no explanations, mar
         var trimmedQuery = query.Trim();
         if (!ValidTSqlStartPattern.IsMatch(trimmedQuery))
         {
-            logger.LogWarning("Invalid T-SQL query received. Query does not start with valid T-SQL keyword: {QueryStart}", 
+            _logger.LogWarning("Invalid T-SQL query received. Query does not start with valid T-SQL keyword: {QueryStart}",
                 trimmedQuery.Length > 50 ? trimmedQuery[..50] + "..." : trimmedQuery);
             
             return @"Error: Invalid T-SQL syntax. This tool only accepts valid Microsoft SQL Server T-SQL statements.
@@ -83,10 +94,10 @@ Please provide only the T-SQL statement without explanations or formatting.";
 
         try
         {
-            logger.LogInformation("Executing T-SQL query starting with: {QueryStart}", 
+            _logger.LogInformation("Executing T-SQL query starting with: {QueryStart}",
                 trimmedQuery.Length > 30 ? trimmedQuery[..30] + "..." : trimmedQuery);
 
-            await using var connection = await connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            await using var connection = await ResolveFactory(connectionName).CreateOpenConnectionAsync(cancellationToken);
             await using var command = connection.CreateCommand();
             command.CommandText = query;
             
@@ -99,7 +110,7 @@ Please provide only the T-SQL statement without explanations or formatting.";
                 // Handle SELECT queries - return data
                 await using var reader = await command.ExecuteReaderAsync(cancellationToken);
                 var result = await FormatQueryResults(reader, cancellationToken);
-                logger.LogInformation("SELECT query executed successfully");
+                _logger.LogInformation("SELECT query executed successfully");
                 return result;
             }
             else
@@ -107,28 +118,31 @@ Please provide only the T-SQL statement without explanations or formatting.";
                 // Handle INSERT/UPDATE/DELETE/DDL - return affected rows
                 var rowsAffected = await command.ExecuteNonQueryAsync(cancellationToken);
                 var result = $"Query executed successfully. Rows affected: {rowsAffected}";
-                logger.LogInformation("Non-SELECT query executed successfully. Rows affected: {RowsAffected}", rowsAffected);
+                _logger.LogInformation("Non-SELECT query executed successfully. Rows affected: {RowsAffected}", rowsAffected);
                 return result;
             }
         }
         catch (DbException ex)
         {
-            logger.LogError(ex, "SQL execution failed with database error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "SQL execution failed with database error: {ErrorMessage}", ex.Message);
             return $"SQL Error: {ex.Message}";
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "SQL execution failed with general error: {ErrorMessage}", ex.Message);
+            _logger.LogError(ex, "SQL execution failed with general error: {ErrorMessage}", ex.Message);
             return $"Error: {ex.Message}";
         }
     }
 
     [McpServerTool, Description("List all tables in the database with basic information.")]
-    public async Task<string> ListTables(CancellationToken cancellationToken = default)
+    public async Task<string> ListTables(
+        [Description("Optional name of the connection string to use, from MSSQL_CONNECTION_STRING_ENV_NAMES. Defaults to the first connection.")]
+        string? connectionName = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            await using var connection = await connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            await using var connection = await ResolveFactory(connectionName).CreateOpenConnectionAsync(cancellationToken);
 
             string query;
             if (connection is SqlConnection)
@@ -170,11 +184,14 @@ Please provide only the T-SQL statement without explanations or formatting.";
     }
 
     [McpServerTool, Description("List all schemas (databases) available in the SQL Server instance.")]
-    public async Task<string> ListSchemas(CancellationToken cancellationToken = default)
+    public async Task<string> ListSchemas(
+        [Description("Optional name of the connection string to use, from MSSQL_CONNECTION_STRING_ENV_NAMES. Defaults to the first connection.")]
+        string? connectionName = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            await using var connection = await connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+            await using var connection = await ResolveFactory(connectionName).CreateOpenConnectionAsync(cancellationToken);
 
             string query;
             if (connection is SqlConnection)

--- a/tests/MSSQL.MCP.IntegrationTests/Tools/SqlExecutionToolTests.cs
+++ b/tests/MSSQL.MCP.IntegrationTests/Tools/SqlExecutionToolTests.cs
@@ -224,7 +224,7 @@ public class SqlExecutionToolTests(DatabaseTestFixture fixture) : IAsyncLifetime
         using var cts = new CancellationTokenSource();
         
         // Start a query
-        var task = _tool.ExecuteSql("SELECT 1", cts.Token);
+        var task = _tool.ExecuteSql("SELECT 1", cancellationToken: cts.Token);
         
         // Cancel immediately
         await cts.CancelAsync();
@@ -241,7 +241,7 @@ public class SqlExecutionToolTests(DatabaseTestFixture fixture) : IAsyncLifetime
         await cts.CancelAsync();
         
         // Should handle cancellation gracefully
-        var result = await _tool.ListTables(cts.Token);
+        var result = await _tool.ListTables(cancellationToken: cts.Token);
         Assert.NotNull(result);
     }
 


### PR DESCRIPTION
## Summary
- allow specifying `MSSQL_CONNECTION_STRING_ENV_NAMES` to load multiple connection strings and register keyed connection factories
- add optional `connectionName` parameter to tools to choose which connection to use
- document multi-connection setup in README

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68945f766cc883329116206ac6301538