### PR TITLE
feat: expose databases as MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ This MCP server provides AI agents with robust, reliable access to Microsoft SQL
 | `list_tables` | List all tables with schema, name, type, and row count |
 | `list_schemas` | List all available schemas/databases in the SQL Server instance |
 
+## Resource Scheme
+
+The server publishes each accessible database as a resource using the `mssql://` URI scheme. Clients can call MCP's
+`list_resources` request to discover databases, which will appear with URIs like `mssql://MyDatabase` and a short description.
+
 ## Configuration
 
 ### Required Environment Variables

--- a/src/MSSQL.MCP/Program.cs
+++ b/src/MSSQL.MCP/Program.cs
@@ -43,7 +43,8 @@ public static class Program
         builder.Services
             .AddMcpServer()
             .WithStdioServerTransport()
-            .WithToolsFromAssembly();
+            .WithToolsFromAssembly()
+            .WithResourceProvidersFromAssembly();
 
         // Build the host
         var host = builder.Build();

--- a/src/MSSQL.MCP/Resources/DatabaseResourceProvider.cs
+++ b/src/MSSQL.MCP/Resources/DatabaseResourceProvider.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using MSSQL.MCP.Database;
+
+namespace MSSQL.MCP.Resources;
+
+/// <summary>
+/// Provides MCP resources representing the databases available on the connected
+/// Microsoft SQL Server instance.
+/// </summary>
+[McpServerResourceProvider]
+public sealed class DatabaseResourceProvider : IMcpServerResourceProvider
+{
+    private readonly IDbConnectionFactory _connectionFactory;
+    private readonly ILogger<DatabaseResourceProvider> _logger;
+
+    public DatabaseResourceProvider(IDbConnectionFactory connectionFactory, ILogger<DatabaseResourceProvider> logger)
+    {
+        _connectionFactory = connectionFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Lists databases as MCP resources using the <c>mssql://</c> URI scheme.
+    /// </summary>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>An async sequence of <see cref="Resource"/> objects.</returns>
+    public async IAsyncEnumerable<Resource> ListResourcesAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await using var connection = await _connectionFactory.CreateOpenConnectionAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT name FROM sys.databases ORDER BY name";
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            var name = reader.GetString(0);
+            yield return new Resource
+            {
+                Name = name,
+                Uri = $"mssql://{name}",
+                Description = $"Microsoft SQL Server database '{name}'"
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide `DatabaseResourceProvider` that lists databases as `mssql://` resources
- wire resource providers into MCP server startup
- document mssql resource scheme

## Testing
- `dotnet test` *(fails: IMcpServerResourceProvider could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6894cdb0bb0883328a2a051f7575bb35